### PR TITLE
Add --break-system-packages

### DIFF
--- a/Claude_Investor.ipynb
+++ b/Claude_Investor.ipynb
@@ -46,7 +46,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install yfinance requests beautifulsoup4"
+        "!pip install yfinance requests beautifulsoup4 --break-system-packages"
       ]
     },
     {


### PR DESCRIPTION
This will ensure that package will override the externally-managed-environment error and install yfinance system-wide.